### PR TITLE
Fixes libraries doesnt get downloaded into sites/all/libraries.

### DIFF
--- a/src/Drupal/Composer/DrupalLibraryInstaller.php
+++ b/src/Drupal/Composer/DrupalLibraryInstaller.php
@@ -37,4 +37,17 @@ class DrupalLibraryInstaller extends LibraryInstaller
       }
       return $path;
     }
+    /**
+     * {@inheritDoc}
+     */
+    public function getInstallPath(PackageInterface $package)
+    {
+      if (empty($this->drupalLibraryMap[$package->getPrettyName()])) {
+        $path = parent::getInstallPath($package);
+      }
+      else {
+        $path = $this->drupalLibrariesPath . $this->drupalLibraryMap[$package->getPrettyName()];
+      }
+      return $path;
+    }
 }

--- a/src/Drupal/Composer/DrupalLibraryInstaller.php
+++ b/src/Drupal/Composer/DrupalLibraryInstaller.php
@@ -27,19 +27,6 @@ class DrupalLibraryInstaller extends LibraryInstaller
     /**
      * {@inheritDoc}
      */
-    public function getPackageBasePath(PackageInterface $package)
-    {
-      if (empty($this->drupalLibraryMap[$package->getPrettyName()])) {
-        $path = parent::getPackageBasePath($package);
-      }
-      else {
-        $path = $this->drupalLibrariesPath . $this->drupalLibraryMap[$package->getPrettyName()];
-      }
-      return $path;
-    }
-    /**
-     * {@inheritDoc}
-     */
     public function getInstallPath(PackageInterface $package)
     {
       if (empty($this->drupalLibraryMap[$package->getPrettyName()])) {


### PR DESCRIPTION
This issue seems to arise as composer updated it's versions and
maybe updated their code specifically in LibraryInstaller. I also
noticed that the getPackageBasePath() doesn't get called instead
the getInstallPath() is being called by adding a simple
var_dump("test"); into the functions during composer install.

I haven't got the root cause for this but this.
