### PR TITLE
Support Composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     "class": "Drupal\\Composer\\DrupalLibraryInstallerPlugin"
   },
   "require": {
-    "composer-plugin-api": "^1.0"
+    "composer-plugin-api": "^1.0 || ^2.0"
   }
 }

--- a/src/Drupal/Composer/DrupalLibraryInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalLibraryInstallerPlugin.php
@@ -8,9 +8,27 @@ use Composer\Plugin\PluginInterface;
 
 class DrupalLibraryInstallerPlugin implements PluginInterface
 {
+    /**
+     * {@inheritDoc}
+     */
     public function activate(Composer $composer, IOInterface $io)
     {
         $installer = new DrupalLibraryInstaller($io, $composer);
         $composer->getInstallationManager()->addInstaller($installer);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
+
 }


### PR DESCRIPTION
Closes #5  Minimal changes to update the plugin to support Composer 2.0.

Changes are based on guidance found in:

composer/composer#8726
https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors
